### PR TITLE
Added gender and suffix sync to a single updateMember

### DIFF
--- a/src/common/utils/suffix-mapping.ts
+++ b/src/common/utils/suffix-mapping.ts
@@ -1,0 +1,20 @@
+const SUFFIX_MAP: Record<string, number> = {
+  jr: 1,
+  'jr.': 1,
+  sr: 2,
+  'sr.': 2,
+  ii: 3,
+  iii: 4,
+  iv: 5,
+  v: 6,
+};
+
+/**
+ * Maps a suffix string (e.g. "Jr", "Sr.", "III") to the corresponding
+ * suffix_id used in the household_members table.
+ * Returns undefined when the input is empty or unrecognized.
+ */
+export function mapSuffixToId(suffix: string | null | undefined): number | undefined {
+  if (!suffix) return undefined;
+  return SUFFIX_MAP[suffix.trim().toLowerCase()];
+}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -21,6 +21,7 @@ import { MailerService } from './mailer.service';
 import { TwilioService } from '../../modules/notifications/twilio.service';
 import { JwtService } from '@nestjs/jwt';
 import { SafeRandom } from '../../common/utils/safe-random';
+import { mapSuffixToId } from '../../common/utils/suffix-mapping';
 import { HouseholdsService } from '../households/households.service';
 
 @Injectable()
@@ -252,6 +253,48 @@ export class AuthService {
         householdCreated = !!householdId;
       } catch {
         // If creation fails, proceed; downstream flows still can create on demand
+      }
+    }
+
+    // Best-effort: sync gender_id and suffix_id from guest user to HOH member
+    if (householdId && this.householdsService) {
+      try {
+        const members = await this.householdsService.listMembers(householdId, guestUser.id);
+        const hoh = Array.isArray(members)
+          ? (
+              members as Array<{
+                id: number;
+                is_head_of_household?: boolean;
+                gender_id?: number | null;
+                suffix_id?: number | null;
+              }>
+            ).find((m) => !!m.is_head_of_household)
+          : undefined;
+        if (hoh) {
+          const patch: Record<string, number> = {};
+
+          if (hoh.gender_id == null || Number.isNaN(hoh.gender_id)) {
+            const g = (guestUser.gender || '').toString().trim().toLowerCase();
+            const mappedGenderId = g === 'male' ? 1 : g === 'female' ? 2 : undefined;
+            if (mappedGenderId !== undefined) patch.gender_id = mappedGenderId;
+          }
+
+          if (hoh.suffix_id == null) {
+            const mappedSuffixId = mapSuffixToId(guestUser.suffix);
+            if (mappedSuffixId !== undefined) patch.suffix_id = mappedSuffixId;
+          }
+
+          if (Object.keys(patch).length > 0) {
+            await this.householdsService.updateMember(
+              householdId,
+              hoh.id,
+              guestUser.id,
+              patch as any,
+            );
+          }
+        }
+      } catch {
+        // best-effort; do not block on member sync
       }
     }
 

--- a/src/modules/registrations/registrations.service.ts
+++ b/src/modules/registrations/registrations.service.ts
@@ -16,6 +16,7 @@ import { EventTimeslot } from '../../entities/event-timeslot.entity';
 import { UsersService } from '../users/users.service';
 import { PantryTrakClient } from '../integrations/pantrytrak.client';
 import { HouseholdsService } from '../households/households.service';
+import { mapSuffixToId } from '../../common/utils/suffix-mapping';
 type AuthUser = {
   authType?: string;
   dbUserId?: number;
@@ -184,7 +185,7 @@ export class RegistrationsService {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         household_id = await this.householdsService.findHouseholdIdByUserId(dbUserId);
 
-        // Best-effort: set HOH gender_id from user's gender string if available
+        // Best-effort: sync gender_id and suffix_id from user to HOH member
         try {
           if (household_id) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -195,23 +196,36 @@ export class RegistrationsService {
                     id: number;
                     is_head_of_household?: boolean;
                     gender_id?: number | null;
+                    suffix_id?: number | null;
                   }>
                 ).find((m) => !!m.is_head_of_household)
               : undefined;
-            const g = (userEntity.gender || '').toString().trim().toLowerCase();
-            const mappedGenderId = g === 'male' ? 1 : g === 'female' ? 2 : undefined;
-            if (
-              hoh &&
-              mappedGenderId !== undefined &&
-              (hoh.gender_id == null || Number.isNaN(hoh.gender_id))
-            ) {
-              await this.householdsService.updateMember(household_id, hoh.id, dbUserId, {
-                gender_id: mappedGenderId,
-              } as any);
+            if (hoh) {
+              const patch: Record<string, number> = {};
+
+              if (hoh.gender_id == null || Number.isNaN(hoh.gender_id)) {
+                const g = (userEntity.gender || '').toString().trim().toLowerCase();
+                const mappedGenderId = g === 'male' ? 1 : g === 'female' ? 2 : undefined;
+                if (mappedGenderId !== undefined) patch.gender_id = mappedGenderId;
+              }
+
+              if (hoh.suffix_id == null) {
+                const mappedSuffixId = mapSuffixToId(userEntity.suffix);
+                if (mappedSuffixId !== undefined) patch.suffix_id = mappedSuffixId;
+              }
+
+              if (Object.keys(patch).length > 0) {
+                await this.householdsService.updateMember(
+                  household_id,
+                  hoh.id,
+                  dbUserId,
+                  patch as any,
+                );
+              }
             }
           }
         } catch {
-          // ignore gender sync failures
+          // ignore member sync failures
         }
       } catch {
         // ignore and fall through to error

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -7,6 +7,7 @@ import { UpdateUserWithHouseholdDto } from './dto/update-user-with-household.dto
 import { HouseholdsService } from '../households/households.service';
 import { UpsertMemberDto } from '../households/dto/upsert-member.dto';
 import { SafeRandom } from '../../common/utils/safe-random';
+import { mapSuffixToId } from '../../common/utils/suffix-mapping';
 import { PantryTrakClient } from '../integrations/pantrytrak.client';
 
 // Minimal shape needed from HouseholdsService.getHouseholdById
@@ -299,32 +300,40 @@ export class UsersService {
       householdPatch as Parameters<typeof this.householdsService.updateHousehold>[2],
     );
 
-    // Ensure head-of-household has gender_id set from user's gender if available
+    // Ensure head-of-household has gender_id and suffix_id set from user data
     try {
-      const membersForGender = await this.householdsService.listMembers(householdId, id);
-      const hohMember = Array.isArray(membersForGender)
+      const membersForSync = await this.householdsService.listMembers(householdId, id);
+      const hohMember = Array.isArray(membersForSync)
         ? (
-            membersForGender as Array<{
+            membersForSync as Array<{
               id: number;
               is_head_of_household?: boolean;
               gender_id?: number | null;
+              suffix_id?: number | null;
             }>
           ).find((m) => !!m.is_head_of_household)
         : undefined;
-      if (hohMember && (hohMember.gender_id == null || Number.isNaN(hohMember.gender_id))) {
-        // Map user's string gender to a numeric gender_id commonly used downstream
-        // 1 = male, 2 = female (fallback: leave unset)
+      if (hohMember) {
         const headUser = await this.findById(id);
-        const g = (headUser.gender || '').toString().trim().toLowerCase();
-        const mappedGenderId = g === 'male' ? 1 : g === 'female' ? 2 : undefined;
-        if (mappedGenderId !== undefined) {
-          await this.householdsService.updateMember(householdId, hohMember.id, id, {
-            gender_id: mappedGenderId,
-          } as any);
+        const patch: Record<string, number> = {};
+
+        if (hohMember.gender_id == null || Number.isNaN(hohMember.gender_id)) {
+          const g = (headUser.gender || '').toString().trim().toLowerCase();
+          const mappedGenderId = g === 'male' ? 1 : g === 'female' ? 2 : undefined;
+          if (mappedGenderId !== undefined) patch.gender_id = mappedGenderId;
+        }
+
+        if (hohMember.suffix_id == null) {
+          const mappedSuffixId = mapSuffixToId(headUser.suffix);
+          if (mappedSuffixId !== undefined) patch.suffix_id = mappedSuffixId;
+        }
+
+        if (Object.keys(patch).length > 0) {
+          await this.householdsService.updateMember(householdId, hohMember.id, id, patch as any);
         }
       }
     } catch {
-      // best-effort; do not block on gender sync
+      // best-effort; do not block on member sync
     }
 
     // After household update, add placeholder members to reach desired counts (if provided).


### PR DESCRIPTION
- common/utils/suffix-mapping.ts (new): Shared utility mapping suffix strings ("Jr", "Sr.", "III", etc.) to their numeric IDs (1-6).
- auth.service.ts: Added best-effort gender + suffix sync after household creation during guest-to-cognito upgrade. Previously neither was synced here.
- registrations.service.ts: Extended the existing gender-only sync to also sync suffix_id from the user's suffix string, using a single updateMember call for both.
- users.service.ts: Same as above — extended the existing gender sync to also handle suffix in a single updateMember call.