### PR TITLE
fixed create user in upgrade user

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -17,6 +17,7 @@ import { Authentication } from '../../entities/authentication.entity';
 import { Credential } from '../../entities/credential.entity';
 import { GuestOrJwtAuthGuard } from './guest-or-jwt.guard';
 import { HouseholdsModule } from '../households/households.module';
+import { PantryTrakClient } from '../integrations/pantrytrak.client';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { HouseholdsModule } from '../households/households.module';
     GuestOrJwtAuthGuard,
     MailerService,
     RolesGuard,
+    PantryTrakClient,
   ],
   exports: [JwtAuthGuard, GuestOrJwtAuthGuard, RolesGuard],
 })

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -24,6 +24,7 @@ import { SafeRandom } from '../../common/utils/safe-random';
 import { mapSuffixToId } from '../../common/utils/suffix-mapping';
 import { HouseholdsService } from '../households/households.service';
 import { CreateHouseholdDto } from '../households/dto/create-household.dto';
+import { PantryTrakClient } from '../integrations/pantrytrak.client';
 
 @Injectable()
 export class AuthService {
@@ -40,6 +41,7 @@ export class AuthService {
     private readonly credentialRepository: Repository<Credential>,
     @Optional() private readonly householdsService?: HouseholdsService,
     @Optional() private readonly twilioService?: TwilioService,
+    @Optional() private readonly pantryTrakClient?: PantryTrakClient,
   ) {}
 
   private async generateUniqueIdentificationCode(): Promise<string> {
@@ -297,6 +299,29 @@ export class AuthService {
       } catch {
         // best-effort; do not block on member sync
       }
+    }
+
+    // Best-effort: push the upgraded user (now user_type='customer') to PantryTrak so
+    // the type change is reflected before any subsequent reservation is attempted.
+    if (this.pantryTrakClient) {
+      try {
+        const ptResult = await this.pantryTrakClient.createUser(guestUser);
+        if (!ptResult.success) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[PantryTrak] upgradeGuest: createUser failed for userId=${guestUser.id} (status=${ptResult.status})`,
+            ptResult.body,
+          );
+        }
+      } catch {
+        // Non-blocking — a sync failure must not prevent the upgrade from completing
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[PantryTrak] upgradeGuest: pantryTrakClient not available, skipping PT sync for userId=' +
+          String(guestUser.id),
+      );
     }
 
     // Invalidate the guest token (delete or expire it)

--- a/src/modules/registrations/registrations.service.ts
+++ b/src/modules/registrations/registrations.service.ts
@@ -523,12 +523,27 @@ export class RegistrationsService {
         const userForSync = await this.usersService.findById(dbUserId);
         const userResult = await this.pantryTrakClient.createUser(userForSync);
         if (!userResult.success) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[PantryTrak] createUser failed (status=${userResult.status}), skipping createReservation to avoid orphaned reservation`,
-            userResult.body,
-          );
-          return;
+          if (userResult.status === 403) {
+            // A 403 from createUser means PT already has this user (e.g. as a guest whose
+            // user_type we are trying to change to 'customer' — PT rejects the type change
+            // but the user record IS valid in PT).  The upgradeGuest flow now attempts to
+            // sync the type change proactively, so this should become rare.  Either way,
+            // the user exists in PT by their id and we can safely create the reservation.
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[PantryTrak] createUser returned 403 for userId=${dbUserId} (user already exists in PT), proceeding with createReservation`,
+              userResult.body,
+            );
+          } else {
+            // Any other failure (401, 5xx, network error) means the user may genuinely
+            // not exist in PT — skip createReservation to avoid an orphaned reservation.
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[PantryTrak] createUser failed (status=${userResult.status}), skipping createReservation to avoid orphaned reservation`,
+              userResult.body,
+            );
+            return;
+          }
         }
         const resResult = await this.pantryTrakClient.createReservation({
           id: saved.id,


### PR DESCRIPTION
When a user goes through the guest flow, updateGuestByToken syncs them to PT as user_type: 'guest'. PT has that record. Then after upgradeGuest, their local user_type becomes 'customer', but PT is never notified (we confirmed AuthService has no PantryTrakClient).

So when registerForEvent fires createUser for the upgraded user, PT receives a payload with user_type: 'customer' for a user it already knows as user_type: 'guest'. PT appears to reject that type change with a hard 403 (no body) — which is exactly the behavior you'd expect if PT treats the user_type field as immutable via that endpoint.

Fresh users work because PT has never seen them before, so there's no type conflict.

1. Root cause fix — sync at upgrade time: In upgradeGuest (auth.service.ts), inject PantryTrakClient and call createUser immediately after saving the upgraded user. This pushes the user_type: 'customer' change to PT at the moment of upgrade, before any reservation attempt. If PT accepts the update at that point, all subsequent createUser calls in registerForEvent would also succeed (no type conflict).
2. Guard logic adjustment: If PT's create_freshtrak_user.php fundamentally doesn't allow updating a guest→customer (returns 403 regardless